### PR TITLE
Patch for code execution vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+build/
+pycsp.egg-info/

--- a/pycsp/parallel/dispatch.py
+++ b/pycsp/parallel/dispatch.py
@@ -439,6 +439,8 @@ class SocketThreadData(object):
                 self.cond.release()
 
     def startThread(self):
+        print("startThread dummy")
+        """
         self.cond.acquire()
         try:
             if self.thread == None:
@@ -446,6 +448,7 @@ class SocketThreadData(object):
                 self.thread.start()
         finally:
             self.cond.release()
+        """
 
             
     def stopThread(self):
@@ -551,6 +554,7 @@ class SocketThreadData(object):
 
     def send(self, addr, header, payload=b"", otherhandler=None):
         # Update message source
+        print("dispatch.send " + str(self.server_addr))
         header._source_host, header._source_port = self.server_addr
         
         m = Message(header, payload)

--- a/pycsp/parallel/dispatch.py
+++ b/pycsp/parallel/dispatch.py
@@ -230,151 +230,6 @@ class QueueBuffer(object):
             self.lock.notify()
         self.lock.release()
 
-
-class SocketThread(threading.Thread):
-    def __init__(self, data):
-        threading.Thread.__init__(self)
-
-        self.channels = data.channels
-        self.processes = data.processes
-        self.data = data
-        self.cond = self.data.cond
-
-        self.daemon = False
-
-        self.finished = False
-
-        
-    def run(self):
-
-        #print "Starting SocketThread"
-        handler = ossocket.ConnHandler()
-
-        while(not self.finished):
-
-            # Performing select.select on possibly EBADF. A lingering socket may be left in the active_socket_list.
-            # The following select.select is robust against Bad File Descriptors, and will remove them from the active_socket_list
-            # The only way to test for a bad file descriptor, is to cause a socket.error exception.
-            
-            OK = False
-            while (not OK):
-                import socket
-                try:
-                    ready, _, exceptready = select.select(self.data.active_socket_list, [], [], 10.0)
-                    OK = True
-                except:
-                    new_socket_list = []
-                    for s in self.data.active_socket_list:
-                        try:
-                            if s.fileno() > 0:
-                                new_socket_list.append(s)
-                        except socket.error:
-                            # Ignoring EBADF file descriptor errors
-                            pass
-                        except ValueError:
-                            # Ignoring file descriptors with a value of -1
-                            pass
-                    self.data.active_socket_list = new_socket_list
-            # Select finished OK
-                    
-            if not ready and not exceptready:
-                # Timeout. Invoke ticks
-                self.cond.acquire()
-                for c in list(self.channels.values()):
-                    c.timeout_tick()
-                self.cond.release()
-
-            else:
-                for s in ready:
-                    if s == self.data.server_socket:
-                        conn, _ = self.data.server_socket.accept()
-                        self.data.active_socket_list.append(conn)
-                    else:
-                        header = Header()
-                        header.cmd = ERROR_CMD
-                        self.cond.acquire()
-                        try:
-                            s.recv_into(header)
-                        except ossocket.socket.error as e:
-                            if e.errno == errno.ECONNRESET:
-                                # Connection has been reset
-                                header.cmd = ERROR_CMD
-                            else:
-                                raise
-                        self.cond.release()
-
-                        if header.cmd == ERROR_CMD:
-                            # connection disconnected
-                            if s in self.data.active_socket_list:
-                                self.data.active_socket_list.remove(s)
-                            s.close()
-                        else:
-                            if (header.cmd & HAS_PAYLOAD):
-                                self.cond.acquire()
-                                payload = ossocket.recvall(s, header.arg)
-                                self.cond.release()
-                            else:
-                                payload = ""
-
-
-                            m = Message(header, payload)
-
-                            if (header.cmd & NATFIX):
-                                # save reverse socket as payload
-                                m.natfix = s
-
-                            self.cond.acquire()
-                            if (header.cmd == SOCKETTHREAD_PING):
-                                if self.data.active_socket_list_add:
-                                    self.data.active_socket_list.extend(self.data.active_socket_list_add)
-                                    self.data.active_socket_list_add = []
-
-                            elif (header.cmd == SOCKETTHREAD_SHUTDOWN):
-                                if self.channels or self.processes:
-                                    # Socketthread is still busy. Thus ignore and expect a later call to deregister to invoke stopThread.
-                                    pass
-                                else:
-                                    self.finished = True
-
-                                    # Remove thread reference
-                                    self.data.thread = None
-
-                                # Do not close sockets as the socketthread may be restarted at a later time
-
-                            elif (header.cmd & PROCESS_CMD):
-                                if header.id in self.processes:
-                                    p = self.processes[header.id]
-                                    p.handle(m)                                
-                                elif (header.cmd & REQ_REPLY):
-                                    raise FatalException("A REQ_REPLY message should always be valid!")
-                                elif (header.cmd & IGN_UNKNOWN):
-                                    raise FatalException("IGN_UNKNOWN should never occur!")
-                                else:
-                                    if not header.id in self.data.processes_unknown:
-                                        self.data.processes_unknown[header.id] = []
-                                    self.data.processes_unknown[header.id].append(m)
-
-                            else:
-                                if header.id in self.channels:
-                                    c = self.channels[header.id]
-                                    if (header.cmd & IS_REPLY):
-                                        c.put_reply(m)
-                                    else:
-                                        c.put_normal(m)
-                                elif (header.cmd & IGN_UNKNOWN):
-                                    pass
-                                else:                                
-                                    if not header.id in self.data.channels_unknown:
-                                        self.data.channels_unknown[header.id] = QueueBuffer()
-
-                                    c = self.data.channels_unknown[header.id]
-
-                                    if (header.cmd & IS_REPLY):
-                                        c.put_reply(m)
-                                    else:
-                                        c.put_normal(m)
-                            self.cond.release()
-
 class SocketThreadData(object):
     def __init__(self, cond):
 
@@ -439,16 +294,6 @@ class SocketThreadData(object):
                 self.cond.release()
 
     def startThread(self):
-        #print("startThread dummy")
-        """
-        self.cond.acquire()
-        try:
-            if self.thread == None:
-                self.thread = SocketThread(self)
-                self.thread.start()
-        finally:
-            self.cond.release()
-        """
         pass
 
             
@@ -555,7 +400,6 @@ class SocketThreadData(object):
 
     def send(self, addr, header, payload=b"", otherhandler=None):
         # Update message source
-        #print("dispatch.send " + str(self.server_addr))
         header._source_host, header._source_port = self.server_addr
         
         m = Message(header, payload)

--- a/pycsp/parallel/dispatch.py
+++ b/pycsp/parallel/dispatch.py
@@ -439,7 +439,7 @@ class SocketThreadData(object):
                 self.cond.release()
 
     def startThread(self):
-        print("startThread dummy")
+        #print("startThread dummy")
         """
         self.cond.acquire()
         try:
@@ -449,6 +449,7 @@ class SocketThreadData(object):
         finally:
             self.cond.release()
         """
+        pass
 
             
     def stopThread(self):
@@ -554,7 +555,7 @@ class SocketThreadData(object):
 
     def send(self, addr, header, payload=b"", otherhandler=None):
         # Update message source
-        print("dispatch.send " + str(self.server_addr))
+        #print("dispatch.send " + str(self.server_addr))
         header._source_host, header._source_port = self.server_addr
         
         m = Message(header, payload)

--- a/pycsp/parallel/ossocket.py
+++ b/pycsp/parallel/ossocket.py
@@ -99,65 +99,7 @@ def _connect(addr, reconnect=True):
 
 def start_server(server_addr=('', 0)):
     """
-    Bind to address and port with the Nagle algorithm disabled.
-
-    Retries binding, if the address and port is in use. Aborts after a specified time.
-    """
-    """
-    ok = False
-    t1 = None
-    sock = None
-    
-    while (not ok):
-        try:
-            if PLATFORM_SYSTEM == 'Darwin':
-                # This is an awfull hack for darwin systems. There is a flaw in
-                # the module function socket.bind(addr), which may cause socket.bind(addr)
-                # to block when multiple OS processes try to bind at the same time.
-                time.sleep(0.1)
-
-
-            # Create IPv4 TCP socket (TODO: add support for IPv6)
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-            # Disable Nagle's algorithem, to enable faster send
-            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-
-            # Enable reuse of sockets in TIME_WAIT state.  
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            
-            # Bind to address
-            print("ossocket bind " + str(server_addr))
-            sock.bind(server_addr)
-
-            # Initiate listening for connections. Create queue of 5 for unaccepted connections
-            sock.listen(5)
-
-            ok = True
-            
-        except socket.error as e:
-            if STDERR_OUTPUT:
-                sys.stderr.write("PyCSP socket issue (%d): %s\n" % (e.errno, e.message))
-            if sock:
-                sock.close()
-            if e.errno != errno.EADDRINUSE:       
-                raise Exception("Fatal error: Could not bind to socket: " + e.message)
-        if not ok:
-            if t1 == None:
-                t1 = time.time()
-            else:
-                if (time.time()-t1) > conf.get(SOCKETS_BIND_TIMEOUT):
-                    raise SocketBindException(server_addr)
-            time.sleep(conf.get(SOCKETS_BIND_RETRY_DELAY))
-
-    # Obtain binded addresses
-    address = sock.getsockname()
-
-    # If bounded address equals '0.0.0.0', then lookup the best candidate for a public IP.
-    if address[0] == '0.0.0.0':
-        address = (_get_ip(), address[1])
-
-    return sock, address
+    Dummified, to prevent a security bug, disabling listening on port.
     """
     return None, ("NONE",-1)
 

--- a/pycsp/parallel/ossocket.py
+++ b/pycsp/parallel/ossocket.py
@@ -72,6 +72,7 @@ def _connect(addr, reconnect=True):
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
             # Connect to addr
+            print('ossocket connect ' + str(addr))
             sock.connect(addr)
 
             connected = True
@@ -102,6 +103,7 @@ def start_server(server_addr=('', 0)):
 
     Retries binding, if the address and port is in use. Aborts after a specified time.
     """
+    """
     ok = False
     t1 = None
     sock = None
@@ -125,6 +127,7 @@ def start_server(server_addr=('', 0)):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             
             # Bind to address
+            print("ossocket bind " + str(server_addr))
             sock.bind(server_addr)
 
             # Initiate listening for connections. Create queue of 5 for unaccepted connections
@@ -155,6 +158,8 @@ def start_server(server_addr=('', 0)):
         address = (_get_ip(), address[1])
 
     return sock, address
+    """
+    return None, ("NONE",-1)
 
 def connectNOcache(addr):
     """


### PR DESCRIPTION
pycsp immediately listens for incoming network connections, on start, in a way that permits a reverse shell.  (It encodes data via pickling, which itself permits arbitrary code execution.)  I believe I've patched this, by means of (and at the cost of) disabling networked channels.  Ideally, a solution would be found which allows networking while preventing ACE, but I don't know how to do that, and this is the best intermediate solution I've managed.